### PR TITLE
Add Multi Monitors Add-On support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Date Menu Formatter",
-  "description": "Allows customization of the date display in the panel.\n\nMight be especially useful if you're using a horizontal panel which does not at all work well with the default date display.\n\nCHANGELOG\nVersion 5: added support for multiple Dash To Panel panels\nVersion 6: fixed issues on earlier Gnome Shell versions\nVersion 10: fixed clock hover style (by bomdia)",
+  "description": "Allows customization of the date display in the panel.\n\nMight be especially useful if you're using a horizontal panel which does not at all work well with the default date display.\n\nCHANGELOG\nVersion 5: added support for multiple Dash To Panel panels\nVersion 6: fixed issues on earlier Gnome Shell versions\nVersion 10: fixed clock hover style (by bomdia)\nVersion 11: added support for multiple Multi Monitors Add-On panels",
   "uuid": "date-menu-formatter@marcinjakubowski.github.com",
   "shell-version": [
     "44", "43", "42", "41", "40"

--- a/prefs.js
+++ b/prefs.js
@@ -124,7 +124,7 @@ class Preferences {
         }.bind(this))
 
 
-        const applyAllPanelsLabel = createLabel( _("Apply to all panels (Dash to Panel)"))
+        const applyAllPanelsLabel = createLabel( _("Apply to all panels (Dash to Panel / Multi Monitors Add-On)"))
         const applyAllPanelsEdit = new Gtk.Switch()
         
 


### PR DESCRIPTION
Add support for https://extensions.gnome.org/extension/921/multi-monitors-add-on/ (https://github.com/spin83/multi-monitors-add-on / https://github.com/realh/multi-monitors-add-on) similarly to what already exists for Dash to Panel.