### PR TITLE
Update for GNOME 45

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,14 +16,16 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-const { GLib, Clutter, St } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SimpleDateFormat } = Me.imports.lib.SimpleDateFormat;
-const Utils = Me.imports.utils;
-const Main = imports.ui.main;
+import GLib from 'gi://GLib';
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
+
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 const MainPanel = Main.panel
 
+import * as Utils from './utils.js';
+import { SimpleDateFormat } from './lib/SimpleDateFormat.js';
 
 let PATTERN = "";
 let USE_DEFAULT_LOCALE = true
@@ -37,8 +39,10 @@ function _getDateMenuButton(panel) {
     return panel.statusArea.dateMenu.get_children()[0];
 }
 
-class Extension {
-    constructor() {
+export default class DateMenuFormatter extends Extension {
+    constructor(metadata) {
+        super(metadata);
+
         this._displays = [this._createDisplay()]
         this._timerId = -1;
         this._settingsChangedId = null;
@@ -58,7 +62,7 @@ class Extension {
     }
 
     _loadSettings() {
-        this._settings = ExtensionUtils.getSettings();
+        this._settings = this.getSettings();
         this._settingsChangedId = this._settings.connect('changed', this._onSettingsChange.bind(this));
         this._onSettingsChange();
     }
@@ -188,8 +192,4 @@ class Extension {
         }
         this._settings = null;
     }
-}
-
-function init() {
-    return new Extension();
 }

--- a/extension.js
+++ b/extension.js
@@ -16,12 +16,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-const { Clutter, St } = imports.gi;
+const { GLib, Clutter, St } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const { SimpleDateFormat } = Me.imports.lib.SimpleDateFormat;
 const Utils = Me.imports.utils;
-const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 const MainPanel = Main.panel
 
@@ -155,7 +154,7 @@ class Extension {
         this._loadSettings();
         const [affectedPanels, _] = this._getPanels();
         this._enableOn(affectedPanels);
-        this._timerId = Mainloop.timeout_add_seconds(1, this.update.bind(this))
+        this._timerId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 1, this.update.bind(this))
         this.update()
     }
 
@@ -178,7 +177,7 @@ class Extension {
         const allPanels = [...affectedPanels, ...unaffectedPanels]
         this._disableOn(allPanels);
         this._restoreIndicator(allPanels);
-        Mainloop.source_remove(this._timerId);
+        GLib.Source.remove(this._timerId);
         if (this._settingsChangedId) {
             this._settings.disconnect(this._settingsChangedId);
             this._settingsChangedId = null;

--- a/lib/SimpleDateFormat.js
+++ b/lib/SimpleDateFormat.js
@@ -7,7 +7,7 @@ License: GNU Lesser General Public License v2.1
  * http://userguide.icu-project.org/formatparse/datetime
  * http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
  */
- var SimpleDateFormat = class {
+export const SimpleDateFormat = class {
 	/**
 	 * @param {string} locale
 	 * @param {boolean=} [utc=false]

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Allows customization of the date display in the panel.\n\nMight be especially useful if you're using a horizontal panel which does not at all work well with the default date display.\n\nCHANGELOG\nVersion 5: added support for multiple Dash To Panel panels\nVersion 6: fixed issues on earlier Gnome Shell versions\nVersion 10: fixed clock hover style (by bomdia)",
   "uuid": "date-menu-formatter@marcinjakubowski.github.com",
   "shell-version": [
-    "44", "43", "42", "41", "40"
+    "45"
   ],
   "version": 10,
   "settings-schema": "org.gnome.shell.extensions.date-menu-formatter",

--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
     "45"
   ],
   "version": 10,
+  "gettext-domain": "date-menu-formatter",
   "settings-schema": "org.gnome.shell.extensions.date-menu-formatter",
   "url": "https://github.com/marcinjakubowski/date-menu-formatter"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -21,21 +21,13 @@
     https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator
     https://extensions.gnome.org/extension/779/clipboard-indicator/
 */
-const Gtk = imports.gi.Gtk;
-const Gio = imports.gi.Gio;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SimpleDateFormat } = Me.imports.lib.SimpleDateFormat;
-const Utils = Me.imports.utils;
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
 
-const Gettext = imports.gettext;
-const _ = Gettext.domain('date-menu-formatter').gettext;
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-function init() {
-    let localeDir = Me.dir.get_child('locale');
-    if (localeDir.query_exists(null))
-        Gettext.bindtextdomain('date-menu-formatter', localeDir.get_path());
-}
+import { SimpleDateFormat } from './lib/SimpleDateFormat.js';
+import * as Utils from './utils.js';
 
 function addBox(box, child) {
     if (imports.gi.versions.Gtk.startsWith("3")) {
@@ -48,7 +40,7 @@ function addBox(box, child) {
 
 
 class Preferences {
-    constructor() {
+    constructor(settings) {
         this.main = new Gtk.Grid({
             margin_top: 10,
             margin_bottom: 10,
@@ -181,7 +173,7 @@ class Preferences {
         
         addRow(help1, help2)
 
-        const settings = ExtensionUtils.getSettings();
+        this.settings = settings;
         settings.bind(Utils.PrefFields.PATTERN, patternEdit.buffer, 'text', Gio.SettingsBindFlags.DEFAULT);
         settings.bind(Utils.PrefFields.USE_DEFAULT_LOCALE, useDefaultLocaleEdit, 'active', Gio.SettingsBindFlags.DEFAULT);
         settings.bind(Utils.PrefFields.CUSTOM_LOCALE, customLocaleEdit.buffer, 'text', Gio.SettingsBindFlags.DEFAULT);
@@ -230,12 +222,14 @@ class Preferences {
     }
 };
 
-function buildPrefsWidget() {
-    let frame = new Gtk.Box();
-    let widget = new Preferences();
-    addBox(frame, widget.main);
-    if (frame.show_all)
-	    frame.show_all();
-    return frame;
+export default class DateMenuFormatterPreferences extends ExtensionPreferences {
+    getPreferencesWidget() {
+        let frame = new Gtk.Box();
+        let widget = new Preferences(this.getSettings());
+        addBox(frame, widget.main);
+        if (frame.show_all)
+	        frame.show_all();
+        return frame;
+    }
 }
 

--- a/utils.js
+++ b/utils.js
@@ -18,3 +18,10 @@ function convertToPattern(str) {
 function convertFromPattern(str) {
     return str.replace(new RegExp('>`<', "g"), "'")
 }
+
+export {
+    PrefFields,
+    getCurrentLocale,
+    convertToPattern,
+    convertFromPattern,
+};


### PR DESCRIPTION
* [chore: bump shell-version to "45"](https://github.com/marcinjakubowski/date-menu-formatter/commit/075d2b35a279281f33a3e6f9a05786fa57b7ba14)
* [feat: add gettext-domain to metadata.json](https://github.com/marcinjakubowski/date-menu-formatter/commit/1c4d7394fc87f8816efdb0565c1008c03e157051)
* [refactor: use GLib instead of deprecated Mainloop](https://github.com/marcinjakubowski/date-menu-formatter/commit/5a3d1a1bbbd0a95031c3b657c92d75dc2525b19b)
* [refactor: port extension.js to ESModules](https://github.com/marcinjakubowski/date-menu-formatter/commit/5bd4d52815fbf5679942e8ac75757b2444350764)
* [refactor: port prefs.js to ESModules](https://github.com/marcinjakubowski/date-menu-formatter/commit/78c0c4c8ce073f5fc2e72aab86cd57a7678ab875)