### PR TITLE
[FIX] Ensure that parser capability are respected

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -115,17 +115,19 @@ export default class DateMenuFormatter extends Extension {
       if (this._timerId !== -1) this.restart()
     }
 
-    const locale = USE_DEFAULT_LOCALE ? getCurrentLocale() : CUSTOM_LOCALE
-    const calendar = USE_DEFAULT_CALENDAR
-      ? getCurrentCalendar()
-      : CUSTOM_CALENDAR
-    const timezone = USE_DEFAULT_TIMEZONE
-      ? getCurrentTimezone()
-      : CUSTOM_TIMEZONE
 
     this._formatters_load_promise.then(() => {
       const formatterKey = this._settings.get_string(prefFields.FORMATTER)
       const formatter = this.formatters.getFormatter(formatterKey)
+      const locale = USE_DEFAULT_LOCALE || !USE_DEFAULT_LOCALE && !formatter.can.customLocale // use default if formatter doesn't support custom
+        ? getCurrentLocale() 
+        : CUSTOM_LOCALE
+      const calendar = USE_DEFAULT_CALENDAR || !USE_DEFAULT_CALENDAR && !formatter.can.customCalendar // use default if formatter doesn't support custom
+        ? getCurrentCalendar()
+        : CUSTOM_CALENDAR
+      const timezone = USE_DEFAULT_TIMEZONE || !USE_DEFAULT_TIMEZONE && !formatter.can.customTimezone // use default if formatter doesn't support custom
+        ? getCurrentTimezone()
+        : CUSTOM_TIMEZONE
       if (formatter) {
         this._formatter = new formatter(timezone, locale, calendar)
       }

--- a/formatters/03_swatch.js
+++ b/formatters/03_swatch.js
@@ -2,10 +2,17 @@ import { DateTime } from '../lib/luxon.js'
 import { createFormatter, FormatterHelp } from '../utils/formatter.js'
 
 export default class extends createFormatter('Swatch Beats') {
+  config(_, locale, calendar) {
+    this._locale = locale
+    this._calendar = calendar
+  }
   format(pattern, date) {
     const dateTime = DateTime.fromJSDate(date)
-      .setZone('Europe/Zurich')
-      .setLocale('CH')
+      .setZone('UTC+1') //fixed as in beats swatch specs
+      .reconfigure({
+        locale: this._locale,
+        outputCalendar: this._calendar,
+      })
     const timeInSeconds =
       (dateTime.hour * 60 + dateTime.minute) * 60 + dateTime.second
     // there are 86.4 seconds in a beat
@@ -14,14 +21,23 @@ export default class extends createFormatter('Swatch Beats') {
     const [beats, subbeats] = Math.abs(timeInSeconds / secondsInABeat)
       .toFixed(2)
       .split('.')
-    return pattern.replaceAll('b', `@${beats}`).replaceAll('s', `.${subbeats}`)
+    return (pattern || '@bbb.s') 
+        .replaceAll('bbb',`${beats.padStart(3, '0')}`)
+        .replaceAll('b', `${beats}`)
+        .replaceAll('s', `${subbeats}`)
   }
 }
 
 export function help() {
-  return new FormatterHelp(
-  '',
-  [['b', 'Beats', '@500']],
-  [['s', 'Sub Beats', '.12']]
-)
+    return new FormatterHelp(
+        '',
+        [
+            ['b', 'Beats', '90'],
+            ['bbb','Beats (Padded)','090']
+        ],
+        [
+            ['s', 'Sub Beats', '12'],
+            ['','','']
+        ]
+    )
 }


### PR DESCRIPTION
when you change parser the settings remain the same even if they are hidden and without any check on the code this settings may influence the correct use of the parser

fixed swatch beats timezone (was already correct partially but influenced by the dst, when swatch beats ignore it, fixed to UTC+1)