### PR TITLE
Keep waiting for Dash to Panel if it enables after this extension

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -241,6 +241,10 @@ export default class DateMenuFormatter extends Extension {
       (display) =>
         (display.style = `font-size: ${FONT_SIZE}pt; font-weight: ${FONT_WEIGHT}; text-align: ${TEXT_ALIGN_MODE}`)
     )
+
+    // Draw straight away. A display added here is empty until the next tick,
+    // which is up to a minute on the lowest update level.
+    if (EVERY !== null) this.update()
   }
 
   // Returns true once connected, false while Dash to Panel is still absent.

--- a/extension.js
+++ b/extension.js
@@ -63,6 +63,7 @@ export default class DateMenuFormatter extends Extension {
     this._timerId = -1
     this._settingsChangedId = null
     this._dashToPanelConnection = null
+    this._extensionManagerConnection = null
     this._formatter = null
     this._update = true
     this.localTimeFile = null
@@ -242,15 +243,37 @@ export default class DateMenuFormatter extends Extension {
     )
   }
 
+  // Returns true once connected, false while Dash to Panel is still absent.
+  _connectDashToPanel() {
+    if (this._dashToPanelConnection) return true
+    if (!global.dashToPanel) return false
+
+    this._dashToPanelConnection = global.dashToPanel.connect(
+      'panels-created',
+      () => this._onSettingsChange()
+    )
+    return true
+  }
+
   enable() {
     EVERY = updateLevel()
     this.formatters = new FormatterManager()
     this._formatters_load_promise = this.formatters.loadFormatters()
     this._displays = [this._createDisplay()]
-    if (global.dashToPanel) {
-      this._dashToPanelConnection = global.dashToPanel.connect(
-        'panels-created',
-        () => this._onSettingsChange()
+    if (!this._connectDashToPanel()) {
+      // Extension load order is not fixed, so Dash to Panel may not have been
+      // enabled yet. Watch for it instead of giving up: without this its extra
+      // panels keep the stock clock until some setting happens to change, with
+      // nothing logged to explain why.
+      this._extensionManagerConnection = Main.extensionManager.connect(
+        'extension-state-changed',
+        () => {
+          if (!this._connectDashToPanel()) return
+          Main.extensionManager.disconnect(this._extensionManagerConnection)
+          this._extensionManagerConnection = null
+          // Its panels already exist, so panels-created will not fire again.
+          this._onSettingsChange()
+        }
       )
     }
     this.localTimeFile = Gio.File.new_for_path('/etc/localtime');
@@ -313,6 +336,10 @@ export default class DateMenuFormatter extends Extension {
     if (this._dashToPanelConnection) {
       global.dashToPanel?.disconnect(this._dashToPanelConnection)
       this._dashToPanelConnection = null
+    }
+    if (this._extensionManagerConnection) {
+      Main.extensionManager.disconnect(this._extensionManagerConnection)
+      this._extensionManagerConnection = null
     }
     this.localTimeFileMonitor.cancel()
     this.localTimeFileMonitor = null


### PR DESCRIPTION
`enable()` subscribes to Dash to Panel's `panels-created` signal only when `global.dashToPanel` already exists:

```js
this._displays = [this._createDisplay()]
if (global.dashToPanel) {
  this._dashToPanelConnection = global.dashToPanel.connect('panels-created', …)
}
```

Extension load order is not fixed, so when this extension enables before Dash to Panel that subscription is never made, and it is never retried. The extension is then stuck with one display on the primary panel for the rest of the session.

### What that looks like

With `apply-all-panels` on and panels on two monitors, the primary panel gets the formatted clock and Dash to Panel's secondary panels keep GNOME's stock clock. Nothing is logged, so there is no hint as to why, and the same session comes up correctly after the next login if the load order happens to differ.

Writing any setting fixes it until logout, because `_onSettingsChange()` re-enumerates the panels. That is a useful workaround but not a fix.

### The change

If Dash to Panel is not present at `enable()` time, watch `Main.extensionManager`'s `extension-state-changed` until it appears, then subscribe and re-enumerate once. Its panels already exist by then, so `panels-created` will not fire again on its own, which is why `_onSettingsChange()` is called explicitly. The listener disconnects as soon as it succeeds, and in `disable()`.

This is the same mechanism ArcMenu uses to wait for Dash to Panel, and Dash to Panel itself uses the signal in `desktopIconsIntegration.js`.

### Second commit

`_onSettingsChange()` inserts the new displays but leaves them empty until the next timer tick. A panel appearing after startup therefore shows nothing until then, which on the lowest update level is a full minute. It now redraws at the point the panel set changes.

Tested on Fedora 44, GNOME Shell 50.0, Wayland, two monitors, Dash to Panel with a panel on each. Both failing and fixed states were reproduced across several logins.
