### PR TITLE
Fix orphaned clock and a timer outliving its displays on disable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -184,6 +184,15 @@ export default class DateMenuFormatter extends Extension {
   _enableOn(panels) {
     panels.forEach((panel, idx) => {
       const dateMenuButton = _getDateMenuButton(panel)
+      // A display left over from a previous enable is unreachable through
+      // this._displays, so the panel would keep two clocks with the stale one
+      // frozen. Checked against the whole list, not against index idx, since a
+      // display that merely moved index is still live.
+      const stale = dateMenuButton.dateMenuFormatterDisplay
+      if (stale && !this._displays.includes(stale)) {
+        stale.destroy()
+        dateMenuButton.dateMenuFormatterDisplay = null
+      }
       if (!this._displays[idx].get_parent()) {
         dateMenuButton.insert_child_at_index(this._displays[idx], 1)
         dateMenuButton.dateMenuFormatterDisplay = this._displays[idx]
@@ -271,7 +280,10 @@ export default class DateMenuFormatter extends Extension {
   }
   stop(force) {
     if (force) {
-      GLib.Source.remove(this._timerId)
+      if (this._timerId) {
+        GLib.Source.remove(this._timerId)
+        this._timerId = null
+      }
     } else {
       this._update = false
     }
@@ -301,7 +313,10 @@ export default class DateMenuFormatter extends Extension {
     const allPanels = [...affectedPanels, ...unaffectedPanels]
     this._disableOn(allPanels)
     this._restoreIndicator(allPanels)
-    this.stop()
+    // Must be forced. Clearing _update only ends the timer on its NEXT tick,
+    // and that tick runs after this method has nulled _displays, throwing
+    // "can't access property forEach, this._displays is null".
+    this.stop(true)
     if (this._settingsChangedId) {
       this._settings.disconnect(this._settingsChangedId)
       this._settingsChangedId = null
@@ -322,7 +337,7 @@ export default class DateMenuFormatter extends Extension {
     this.formatters = null
     this._formatter = null
     this._formatters_load_promise = null
-    this.display?.forEach((d) => d?.destroy())
+    this._displays?.forEach((d) => d?.destroy())
     this._displays = null
   }
 }


### PR DESCRIPTION
Two clocks on a secondary Dash to Panel panel, the stale one frozen, after the extensions are disabled and re-enabled (screen lock/unlock is the easy way to hit it). Observed on GNOME Shell 50 / Wayland, Fedora 44, with Dash to Panel on two monitors. The primary panel is unaffected.

Three separate things combine.

**The timer outlives its displays.** `disable()` calls `this.stop()` with no argument, so only `_update` is cleared and the `GLib.timeout` stays armed. `disable()` then sets `this._displays = null`, and the next tick runs `update()` against it:

```
JS ERROR: TypeError: can't access property "forEach", this._displays is null
  setText@…/extension.js:338
  update@…/extension.js:343
  start/this._timerId<@…/extension.js:302
```

That is also what freezes the label: the callback dies mid-update, so whatever it last rendered stays on screen.

**No display is ever destroyed.** The last lines of `disable()` read:

```js
this.display?.forEach((d) => d?.destroy())
```

`this.display` (singular) does not exist. The optional chaining swallows it silently, so the loop never runs.

**The leftover then doubles up.** A display still parented on a secondary panel survives into the next `enable()`, which builds fresh displays and inserts one at index 1 beside it, then overwrites `dateMenuButton.dateMenuFormatterDisplay` so the old one is unreachable from `_displays`. `MainPanel` is always in `_getPanels()` and gets cleaned properly, which is why only the extra panels show it.

Changes:

- `disable()` now calls `stop(true)` so the source is removed rather than left to fire once more.
- `stop(true)` guards on `_timerId` and clears it, so a forced stop cannot double-remove the source.
- `this.display?.forEach` corrected to `this._displays?.forEach`.
- `_enableOn()` destroys a display the button still references when the current `_displays` no longer owns it. Compared against the whole list rather than the index, since a display that merely moved index is still live.

The `TypeError` above is from my own journal on a machine showing the duplicate, and all three defects are present on current `master`. I have not yet run a patched build through a full set of lock/unlock cycles, so treat the fix as reasoned from the code rather than soak-tested.
