### PR TITLE
Re-arm the update timer when GC kills its GLib source (fixes the #14 freeze)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,7 @@
 import GLib from 'gi://GLib'
 import Gio from 'gi://Gio';
 import Clutter from 'gi://Clutter'
+import GnomeDesktop from 'gi://GnomeDesktop'
 import St from 'gi://St'
 
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js'
@@ -30,6 +31,7 @@ import {
   getCurrentCalendar,
   getCurrentTimezone,
   updateLevel,
+  MINUTE_IN_MS,
   TEXT_ALIGN_CENTER,
 } from './utils/general.js'
 import { FormatterManager } from './utils/formatter.js'
@@ -61,6 +63,8 @@ export default class DateMenuFormatter extends Extension {
     this._formatters_load_promise = null
     this._displays = null
     this._timerId = -1
+    this._wallClock = null
+    this._wallClockId = null
     this._settingsChangedId = null
     this._dashToPanelConnection = null
     this._formatter = null
@@ -262,18 +266,64 @@ export default class DateMenuFormatter extends Extension {
     this._enableOn(affectedPanels)
     this.start()
   }
+  // Returns true if our GLib timeout source is still alive in the main loop.
+  // GJS blocks JS callbacks that would run during a GC sweep, and a blocked
+  // SourceFunc is treated as returning FALSE, so GLib destroys the source for
+  // good and the clock silently freezes. There is no way to detect that from
+  // inside the callback, so we probe the main context instead.
+  _timerAlive() {
+    if (this._timerId === -1) return false
+    return GLib.MainContext.default().find_source_by_id(this._timerId) !== null
+  }
+
+  _removeTimer() {
+    if (this._timerId !== -1) {
+      if (this._timerAlive()) GLib.Source.remove(this._timerId)
+      this._timerId = -1
+    }
+  }
+
   start() {
     this._update = true
+    this._removeTimer()
     this._timerId = GLib.timeout_add(EVERY.priority, EVERY.timeout, () =>
       this.update()
     )
+
+    // Watchdog: GnomeDesktop.WallClock drives its 'clock' property from C, so
+    // notify::clock keeps being emitted even when JS timeouts have been killed
+    // by the GC-sweep guard (a blocked signal handler only misses that single
+    // emission; the connection itself survives). This is the same clock source
+    // GNOME's own panel uses, which is why the stock clock never freezes.
+    // Re-arm the timeout whenever we notice it has died.
+    if (!this._wallClock) {
+      this._wallClock = new GnomeDesktop.WallClock()
+      this._wallClockId = this._wallClock.connect('notify::clock', () => {
+        if (!this._update || this._timerAlive()) return
+        this._timerId = GLib.timeout_add(EVERY.priority, EVERY.timeout, () =>
+          this.update()
+        )
+        this.update()
+      })
+    }
+    // Only ask the wall clock for per-second resolution when the configured
+    // interval is sub-minute; at update level 0 a minute-granular watchdog is
+    // enough and avoids waking up every second for nothing.
+    this._wallClock.force_seconds = EVERY.timeout < MINUTE_IN_MS
+
     this.update()
   }
   stop(force) {
     if (force) {
-      GLib.Source.remove(this._timerId)
+      this._removeTimer()
     } else {
       this._update = false
+      this._removeTimer()
+      if (this._wallClockId) {
+        this._wallClock.disconnect(this._wallClockId)
+        this._wallClockId = null
+      }
+      this._wallClock = null
     }
   }
   restart() {
@@ -282,6 +332,7 @@ export default class DateMenuFormatter extends Extension {
   }
 
   update() {
+    if (!this._update || !this._displays) return GLib.SOURCE_REMOVE
     const setText = (text) =>
       this._displays.forEach((display) => (display.text = text))
     try {
@@ -292,7 +343,7 @@ export default class DateMenuFormatter extends Extension {
       if (this._formatter !== null && this._formatter !== undefined)
         console.log('DateMenuFormatter: ' + e.message)
     }
-    return this._update
+    return GLib.SOURCE_CONTINUE
   }
 
   disable() {

--- a/utils/general.js
+++ b/utils/general.js
@@ -1,5 +1,7 @@
 import GLib from 'gi://GLib'
 
+export const MINUTE_IN_MS = 1000 * 60
+
 export const TEXT_ALIGN_START = 'left'
 export const TEXT_ALIGN_CENTER = 'center'
 export const TEXT_ALIGN_END = 'right'
@@ -22,7 +24,7 @@ export function getCurrentCalendar() {
 export function updateLevel(lvl) {
   if (typeof lvl === 'number' && !Number.isNaN(lvl)) {
     if (lvl === 0)
-      return { lvl, priority: GLib.PRIORITY_DEFAULT_IDLE, timeout: 1000 * 60 }
+      return { lvl, priority: GLib.PRIORITY_DEFAULT_IDLE, timeout: MINUTE_IN_MS }
     if (lvl > 0 && lvl <= 7)
       return { lvl, priority: GLib.PRIORITY_DEFAULT, timeout: 1000 / lvl }
     if (lvl > 7 && lvl <= 15)


### PR DESCRIPTION
Fixes the freeze in #14.

## Cause

GJS blocks JS callbacks that would run during a GC sweep:

```
Attempting to run a JS callback during garbage collection. ... it has been blocked.
The offending callback was SourceFunc().
```

A blocked `SourceFunc` returns no value, which GLib reads as `G_SOURCE_REMOVE`, so the timeout is destroyed permanently. `update()` is never entered again, so it cannot log or throw, and the label keeps whatever it last rendered.

The stock panel clock is unaffected by the same GC storm because `dateMenu.js` keeps it out of JS entirely:

```js
this._clock.bind_property('clock', this._clockDisplay, 'text', GObject.BindingFlags.SYNC_CREATE);
```

## Fix

Re-arm the timeout from a `GnomeDesktop.WallClock`'s `notify::clock`, which is driven from C:

```js
this._wallClockId = this._wallClock.connect('notify::clock', () => {
  if (!this._update || this._timerAlive()) return
  this._timerId = GLib.timeout_add(EVERY.priority, EVERY.timeout, () => this.update())
  this.update()
})
```

This relies on an asymmetry in the GC guard: a blocked `SourceFunc` is read as `SOURCE_REMOVE` and the source dies, whereas a blocked signal handler only misses that one emission and stays connected. In my logs `notify on GnomeWallClock` was itself blocked 7 times in one session and the clock kept ticking.

Liveness is probed from outside the callback, since a callback that never runs cannot report on itself:

```js
_timerAlive() {
  if (this._timerId === -1) return false
  return GLib.MainContext.default().find_source_by_id(this._timerId) !== null
}
```

`force_seconds` is set only when the configured interval is sub-minute, so update level 0 keeps a minute-granular watchdog.

Two related corrections:

- `update()` returns `GLib.SOURCE_CONTINUE`/`SOURCE_REMOVE` explicitly instead of the bare `_update` flag. A non-forced `stop()` set `_update = false`, and returning that from the callback destroyed the source with no path back.
- `_removeTimer()` clears `_timerId` and only removes a live source, taking `Source ID NNNN was not found when attempting to remove it` from 31 per session to 0.

## Verification

GNOME Shell 46.0 / X11 / Ubuntu 24.04, gjs 1.80.2, update level 1.

Before: froze ~1s after every shell start, reproducible across a full logout/login, 11–34 `SourceFunc` kills per session.

After: ticking continuously through a session logging 11 such kills, with no `DateMenuFormatter:` errors.

Tested on one machine and one GNOME version. The GC storm originates in shell-internal window tracking, so hit rate varies with extension set and workload.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
